### PR TITLE
chore(ci): Replace archived actions-rs actions

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -15,7 +15,7 @@
 
 name: build wasm
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linux:

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -23,11 +23,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Build with rust
         run: |
           cd ${{ github.workspace }}/shenyu-wasm-build
@@ -44,11 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Build with rust
         run: |
           cd ${{ github.workspace }}/shenyu-wasm-build
@@ -66,11 +62,9 @@ jobs:
       - uses: actions/checkout@v2
         continue-on-error: true
       - name: Set up rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        run: |
+           rustup toolchain add --profile=minimal stable
+           rustup override set stable
       - name: Build with rust
         run: |
           cd ${{ github.workspace }}/shenyu-wasm-build

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -17,6 +17,9 @@ name: build wasm
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The actions-rs org has been archived for years at this point and it doesn't look like it's coming back. For security reasons we are going to remove it from the list of allowed actions in the org soon. (See https://github.com/apache/infrastructure-actions)
